### PR TITLE
Olivekl docs cleanup

### DIFF
--- a/docs/build_integration.md
+++ b/docs/build_integration.md
@@ -257,10 +257,10 @@ To improve your fuzz target ability to find bugs faster, please read
 ## Running ClusterFuzzLite
 
 Once everything is complete, you are ready to set up ClusterFuzzLite to run on
-your CI. Check out the [docs on Running ClusterFuzzLite] to do this.
+your CI. Check out the instructions on [Running ClusterFuzzLite] to do this.
 
 [fuzz targets]: https://github.com/google/fuzzing/blob/masteer/docs/glossary.md#fuzz-target
 [libFuzzer targets]: {{ site.baseurl}}/reference/glossary/#fuzz-target
 [OSS-Fuzz]: https://github.com/google/oss-fuzz
 [`Dockerfile`]: #dockerfile
-[documents on Running ClusterFuzzLite]: {{ site.baseurl}}/running-clusterfuzzlite/
+[Running ClusterFuzzLite]: {{ site.baseurl}}/running-clusterfuzzlite/

--- a/docs/build_integration.md
+++ b/docs/build_integration.md
@@ -138,7 +138,7 @@ Your build.sh should not delete any source code. Source code is needed for code
 coverage reports.
 
 The `$WORK` environment variable defines a directory you where build.sh can
-store intermediate files. !!! Delete this?
+store intermediate files. 
 
 Here's an example build.sh from Expat:
 

--- a/docs/developing_clusterfuzzlite.md
+++ b/docs/developing_clusterfuzzlite.md
@@ -13,13 +13,6 @@ permalink: /developing-clusterfuzzlite/
 {:toc}
 ---
 
-TODO
-
-Explain external
-Explain multiple images
-Explain environment variables
-Explain filestore
-
 ## Code location
 
 The code for ClusterFuzzLite is located in the [`infra/cifuzz` directory] of the

--- a/docs/developing_clusterfuzzlite.md
+++ b/docs/developing_clusterfuzzlite.md
@@ -13,6 +13,13 @@ permalink: /developing-clusterfuzzlite/
 {:toc}
 ---
 
+TODO
+
+Explain external
+Explain multiple images
+Explain environment variables
+Explain filestore
+
 ## Code location
 
 The code for ClusterFuzzLite is located in the [`infra/cifuzz` directory] of the

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -22,7 +22,8 @@ The program that creates the inputs is called a fuzzer.
 Fuzzing is highly effective at finding bugs missed by manually written tests,
 code review, or auditing.
 Fuzzing has found thousands of bugs in mature software such as Chrome, OpenSSL,
-and Curl. When done well, fuzzing is able to find bugs in virtually any code.
+and Curl. 
+When done well, fuzzing is able to find bugs in virtually any code.
 
 ### libFuzzer
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -22,9 +22,7 @@ The program that creates the inputs is called a fuzzer.
 Fuzzing is highly effective at finding bugs missed by manually written tests,
 code review, or auditing.
 Fuzzing has found thousands of bugs in mature software such as Chrome, OpenSSL,
-and Curl.
-If fuzzing isn't finding bugs in your code, your code is probably not bug free,
-you are probably not fuzzing well.
+and Curl. When done well, fuzzing is able to find bugs in virtually any code.
 
 ### libFuzzer
 
@@ -50,20 +48,18 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 ```
 Clang's `-fsanitizer=fuzzer` option will link this fuzz target function against
 libFuzzer, producing a fuzzer binary that will fuzz your target code when run.
-Note that in ClusterFuzzLite, you will not use this flag directly, you should
-use the `$LIB_FUZZING_ENGINE` environment variable, which we discuss later in
+Note that in ClusterFuzzLite, you will not use this flag directly. Instead, you should
+use the `$LIB_FUZZING_ENGINE` environment variable, which is discussed in more detail in
 [Build Integration].
 
 ### Sanitizers
 
 Sanitizers are tools that detect bugs in code (typically "native code" such as
 C/C++, Rust, Go, and Swift) and report bugs by crashing.
-Sanitizers are useful outside of fuzzing, but are particularly helpful when
-fuzzing.
-ClusterFuzzLite relies on sanitizers to to detect bugs that would otherwise be
+ClusterFuzzLite relies on sanitizers to detect bugs that would otherwise be
 missed.
-Sanitizers work by instructing clang to add compile-time instrumentation,
-therefore different builds are needed to use different sanitizers.
+Sanitizers work by instructing clang to add compile-time instrumentation, so different
+builds are needed to use different sanitizers.
 
 The sanitizers ClusterFuzzLite uses are:
 - [AddressSanitizer (ASan)] : For detecting memory safety issues. This is the
@@ -76,11 +72,12 @@ The sanitizers ClusterFuzzLite uses are:
   entirely instrumented with MSan. If any part of the binary is not instrumented
   with MSan, MSan will report false positives.
 
-The ClusterFuzzLite codebase uses shorter names for the sanitizers. So when
-referring to a sanitizer when giving input to ClusterFuzzLite, ASan is
+The ClusterFuzzLite codebase uses shorter names for the sanitizers. When
+referring to a sanitizer as an input to ClusterFuzzLite, ASan is
 `address`, UBSan is `ubsan` and MSan is `memory`.
 
-With that, you have enough background to build fuzzers for ClusterFuzzLite. Continue on to [Build Integration] for directions. 
+With that, you have enough background to build fuzzers for ClusterFuzzLite. Continue on 
+to [Build Integration] for directions on integrating your project with ClusterFuzzLite's build system. 
 
 [Fuzzing]: https://en.wikipedia.org/wiki/Fuzzing
 [LibFuzzer]: https://llvm.org/docs/LibFuzzer.html

--- a/docs/running-clusterfuzzlite/github_actions.md
+++ b/docs/running-clusterfuzzlite/github_actions.md
@@ -13,7 +13,7 @@ permalink: /running-clusterfuzzlite/github-actions/
 {:toc}
 ---
 
-This page explains how to set up ClusterFuzzLite to run on GitHub Actions.
+This page explains how to set up ClusterFuzzLite to run on [GitHub Actions](https://docs.github.com/en/actions).
 To get the most of this page, you should have already set up your
 [build integration] and read the more
 [high-level document on running ClusterFuzzLite].
@@ -31,7 +31,6 @@ To enable more features, we recommend having these additional files:
 
 These workflow files are used by GitHub actions to run the ClusterFuzzLite
 actions.
-GitHub Actions documentation can be found [here](https://docs.github.com/en/actions).
 For a complete example on a real project, see
 <https://github.com/oliverchang/curl>.
 


### PR DESCRIPTION
General cleanup: remove TODOs, fix broken link, move a link earlier, fix typos, remove or reword a few sentences