### PR TITLE
Add screenshots to github actions for the following:

### DIFF
--- a/docs/running-clusterfuzzlite/github_actions.md
+++ b/docs/running-clusterfuzzlite/github_actions.md
@@ -13,7 +13,7 @@ permalink: /running-clusterfuzzlite/github-actions/
 {:toc}
 ---
 
-This page explains how to set up ClusterFuzzLite to run on [GitHub Actions](https://docs.github.com/en/actions).
+This page explains how to set up ClusterFuzzLite to run on [GitHub Actions].
 To get the most of this page, you should have already set up your
 [build integration] and read the more
 [high-level document on running ClusterFuzzLite].
@@ -96,8 +96,12 @@ However, you can edit the file to:
   discussed [later on], feel free to skip this at first.
 
 Merge this file into your GitHub repo and open a pull request to test it out.
-Now that we have discussed setting up code change fuzzing on pull requests, let's
-look at setting up other tasks to get the most out of ClusterFuzzLite.
+To download crashes from code change fuzzing, please see the [section
+on downloading artifacts].
+Now that we have discussed setting up code change fuzzing on pull requests,
+let's look at setting up other tasks to get the most out of ClusterFuzzLite.
+
+![github-actions-crash]
 
 [later on]: #storage-repo
 
@@ -313,7 +317,17 @@ But here is where `storage-repo`, `storage-repo-branch`, and
 If `storage-repo` is set and `storage-repo-branch-coverage` is "gh-pages" (the
 default), then coverage reports can be viewed at
 `https://USERNAME.github.io/STORAGE-REPO-NAME/coverage/latest/report/linux/report.html`.
-This should be much nicer than downloading the coverage report as an artifact.
+This should be much nicer than downloading the coverage report as an artifact
+and can be seen in the screenshot below:
+![github-actions-coverage-report]
+
+## Downloading artifacts
+
+To download an artifact from a ClusterFuzzLite run:
+- Click on the summary from the run.
+![github-actions-summary]
+- Click on the artifact you with to download from the summary page.
+![github-actions-download-crash]
 
 ## Extra configuration
 
@@ -328,11 +342,14 @@ An empty repository for this is sufficient.
 
 You'll need to set up a [personal access token] with write permissions to the
 storage repo and add it as a [repository secret] called
-`PERSONAL_ACCESS_TOKEN`. This is because the default GitHub auth token is not
-able to write to other repositories.
+`PERSONAL_ACCESS_TOKEN`.
+This is because the default GitHub auth token is not able to write to other
+repositories.
 Note that if you run into [issues with the storage repo], you may have
 accidentally set the secret as an *environment secret* instead of a
 *repository secret*.
+![new-repo-secret]
+![personal-access-token]
 
 If you would like PR fuzzing to only run fuzzers affected by the current
 change, you'll need to add these same options to the ["Build Fuzzers" step
@@ -371,3 +388,11 @@ like so:
 [storage repo]: #storage
 [continuous builds]: #continuous-builds
 [batch fuzzing]: #batch-fuzzing
+[GitHub Actions]: https://docs.github.com/en/actions
+[github-actions-crash]: https://storage.googleapis.com/clusterfuzzlite-public/images/github-actions-crash.png
+[github-actions-coverage-report]: https://storage.googleapis.com/clusterfuzzlite-public/images/github-actions-coverage-report.png
+[section on downloading artifacts]: #downloading-artifacts
+[github-actions-summary]: https://storage.googleapis.com/clusterfuzzlite-public/images/github-actions-summary.png
+[github-actions-download-crash]: https://storage.googleapis.com/clusterfuzzlite-public/images/github-actions-download-crash.png
+[new-repo-secret]: https://storage.googleapis.com/clusterfuzzlite-public/images/new-repo-secret.png
+[personal-access-token]: https://storage.googleapis.com/clusterfuzzlite-public/images/personal-access-token.png

--- a/docs/running_clusterfuzzlite.md
+++ b/docs/running_clusterfuzzlite.md
@@ -14,17 +14,22 @@ permalink: /running-clusterfuzzlite/
 ---
 
 ## Overview
-![overview]({{ site.baseurl }}/assets/overview.png)
+![overview]
 
-Before running ClusterFuzzLite, you must integrate your project with ClusterFuzzLite's build system to build your project's fuzzers. See [Integrating with ClusterFuzzLite's build system] if you haven't already taken this step.
+Before running ClusterFuzzLite, you must integrate your project with
+ClusterFuzzLite's build system to build your project's fuzzers.
+See [Integrating with ClusterFuzzLite's build system] if you haven't already
+taken this step.
 
 Once your project's fuzzers can be built and run by the OSS-Fuzz/ClusterFuzzLite
 helper script, it is ready to be fuzzed by ClusterFuzzLite.
 
-The exact method for running ClusterFuzzLite will depend on which CI system you are using.
+The exact method for running ClusterFuzzLite will depend on which CI system you
+are using.
 The rest of this page explains important concepts and configuration options
 that are agnostic to which CI system you are using.
-After reading this page, see the [subguides] for instructions specific to your particular CI system (e.g. [GitHub Actions] or [Google Cloud Build]).
+After reading this page, see the [subguides] for instructions specific to your
+particular CI system (e.g. [GitHub Actions] or [Google Cloud Build]).
 
 ## ClusterFuzzLite modes
 
@@ -38,41 +43,49 @@ ClusterFuzzLite can be instructed to perform any of these functions using the
 ### Code Change Fuzzing ("code-change") {#code-change}
 
 One of the core ways to use ClusterFuzzLite is to fuzz code changes that
-were introduced in a pull request/code review or commit. Code change fuzzing allows ClusterFuzzLite to find bugs before they are
-commited into your code and while they are easiest to fix.
+were introduced in a pull request/code review or commit.
+Code change fuzzing allows ClusterFuzzLite to find bugs before they are commited
+into your code and while they are easiest to fix.
 
-Code change fuzzing is designed to be fast so that it integrates easily into your development workcycle:
+Code change fuzzing is designed to be fast so that it integrates easily into
+your development workcycle:
 - It defaults to running for 10 minutes, [though this can be changed].
 - It quits after finding a single crash, even if there are other fuzzers to
    run.
-   
-Running only code change fuzzing is the easiest way to use ClusterFuzzLite. 
-However, we suggest using code change fuzzing in conjunction with other modes to gain ClusterFuzzLite's full benefits. 
-For example, running [batch fuzzing] will develop a [corpus] that can be used by code change fuzzing. 
-If no corpus is available from batch fuzzing, code change fuzzing will start from nothing or the provided seed corpus. 
+
+Running only code change fuzzing is the easiest way to use ClusterFuzzLite.
+However, we suggest using code change fuzzing in conjunction with other modes to
+gain ClusterFuzzLite's full benefits.
+For example, running [batch fuzzing] will develop a [corpus] that can be used by
+code change fuzzing.
+If no corpus is available from batch fuzzing, code change fuzzing will start
+from nothing or the provided seed corpus.
 Furthermore, when you first use ClusterFuzzLite, code change
-fuzzing will not report the bugs that already exist in your codebase, while [batch fuzzing] will. 
-See also [Code Coverage Report Generation] and [Continuous Builds] for additional functionalities.
+fuzzing will not report the bugs that already exist in your codebase, while
+[batch fuzzing] will.
+See also [Code Coverage Report Generation] and [Continuous Builds] for
+additional functionalities.
+![github-actions-crash]
 
 ### Batch Fuzzing ("batch") {#batch}
 
-In batch fuzzing mode all fuzzers are run
-for a preset longer amount of time. Unlike in code change mode, batch fuzzing will not exit immediately upon
-discovering a bug. It will keep running other fuzzers until reaching
-the allotted fuzzing time.
+In batch fuzzing mode all fuzzers are run for a preset longer amount of time.
+Unlike in code change mode, batch fuzzing will not exit immediately upon
+discovering a bug.
+It will keep running other fuzzers until reaching the allotted fuzzing time.
 
 Given the longer runtime, we suggest batch fuzzing should be run on a schedule
-such as once daily, rather than on code changes. 
+such as once daily, rather than on code changes.
 
 By running for a longer amount of time, batch fuzzing
 serves two important purposes:
 - It can find bugs that are missed or are not reported by code change fuzzing.
-   Note that batch fuzzing reports all crashes, not just "new" ones.
+  Note that batch fuzzing reports all crashes, not just "new" ones.
 - It builds a [corpus] for each of your fuzz targets, leading to more
-   code coverage and better bug discovery.
-   This corpus will be used by [Code coverage report generation],
-   [code change fuzzing], and later runs of batch fuzzing.
-   The corpus is saved using your CI system's feature for storing files.
+  code coverage and better bug discovery.
+  This corpus will be used by [Code coverage report generation],
+  [code change fuzzing], and later runs of batch fuzzing.
+  The corpus is saved using your CI system's feature for storing files.
 
 [corpus]: https://github.com/google/fuzzing/blob/master/docs/glossary.md#corpus
 
@@ -81,53 +94,70 @@ serves two important purposes:
 Over time, redundant testcases will get introduced into your fuzzer's corpuses
 during [batch fuzzing].
 
-Corpus pruning is a helper function that minimizes the corpuses by removing corpus files (testcases) that
-do not increase the fuzzer's code coverage.
+Corpus pruning is a helper function that minimizes the corpuses by removing
+corpus files (testcases) that do not increase the fuzzer's code coverage.
 
-If you are using [batch fuzzing], you should run corpus pruning once a day to prevent buildup of these redundant
-testcases and keep fuzzing efficient. Corpus pruning should be considered mandatory when you are using [batch fuzzing] but otherwise should not be used.
+If you are using [batch fuzzing], you should run corpus pruning once a day to
+prevent buildup of these redundant testcases and keep fuzzing efficient.
+Corpus pruning should be considered mandatory when you are using [batch fuzzing]
+but otherwise should not be used.
 
 ### Code Coverage Report Generation ("coverage") {#coverage}
 
-Code coverage report generation is a helper function that can be used when batch fuzzing is enabled. 
+Code coverage report generation is a helper function that can be used when batch
+fuzzing is enabled.
 This mode uses the corpus developed during batch fuzzing to generate an HTML
 coverage report that shows which parts of your code are covered by
 fuzzing.
 
 The data from coverage reports is also used by [code change fuzzing] to
-determine which fuzzers are affected by a code change. If code change fuzzing can determine which fuzzers are affected, it will run only those fuzzers. Otherwise, it will run all of them. Even if you are primarily interested in using only code coverage mode, we suggest also using 
-batch fuzzing and code coverage report generation as well, since they add this functionality to your code coverage fuzzing.
+determine which fuzzers are affected by a code change.
+If code change fuzzing can determine which fuzzers are affected, it will run
+only those fuzzers.
+Otherwise, it will run all of them.
+Coverage report generation uses the corpuses saved by [batch fuzzing] and
+therefore should only be used if batch fuzzing is enabled.
+It is not required if [batch fuzzing] is enabled, but is strongly recommended.
 
-Since code coverage report generation uses the corpuses saved by batch fuzzing, it should be used only if batch fuzzing is enabled. 
+Since code coverage report generation uses the corpuses saved by batch fuzzing,
+it should be used only if batch fuzzing is enabled.
+![github-actions-coverage-report]
 
 ### Continuous Builds
 
-Continuous builds are not actually a mode of running fuzzers but is an additional
-"task" for ClusterFuzzLite that you can set up (see [subguides]). Instead of running the fuzzers
-after building them, in continuous builds, the builds are saved for later use by the
-[code change fuzzing] mode. 
+Continuous builds are not actually a mode of running fuzzers but is an
+additional "task" for ClusterFuzzLite that you can set up (see [subguides]).
+Instead of running the fuzzers after building them, in continuous builds, the
+builds are saved for later use by the [code change fuzzing] mode.
 
 The continuous builds task enables code change fuzzing to identify whether a
-crash was introduced by the code change or if it was pre-existing. If the cause of the crash
-was pre-existing, the crash is not reported by code change fuzzing. If code change fuzzing is run without the continuous builds task, all crashes 
+crash was introduced by the code change or if it was pre-existing.
+If the cause of the crash was pre-existing, the crash is not reported by code
+change fuzzing.
+If code change fuzzing is run without the continuous builds task, all crashes
 will be reported.
 
 ## Configuration Options
 
-This section is an overview of the configuration options you can set when running ClusterFuzzLite.
-See the [subguides] for details on how to set each configuration within your specific CI system. 
+This section is an overview of the configuration options you can set when
+running ClusterFuzzLite.
+See the [subguides] for details on how to set each configuration within your
+specific CI system.
 
 - `language`: The language your target code is written in. Defaults to `c++`.
   This should be the same as the value you set in `project.yaml`. See [this
   explanation] for more details.
 
 - `fuzz-seconds`: Instructs ClusterFuzzLite on how long to spend fuzzing, in
-  seconds. The default is 600 seconds, which is an appropriate starting point for code change fuzzing. You should 
-  increase this number to spend more time batch fuzzing.
+  seconds.
+  The default is 600 seconds, which is an appropriate starting point for code
+  change fuzzing.
+  You should increase this number to spend more time batch fuzzing.
 
 - `sanitizer`: Determines the sanitizer to build and run fuzz targets with. The
   choices are `'address'`, `'undefined'`, `'memory'` and `'coverage'` (for
-  coverage report generation). The default is `'address'`. See [Sanitizers] for more information.
+  coverage report generation). The default is `'address'`.
+  See [Sanitizers] for more information.
 
 - `mode`: The mode for ClusterFuzzLite to execute. `code-change` by default. See
   [ClusterFuzzLite modes] for more details on how to run different modes.
@@ -137,14 +167,16 @@ See the [subguides] for details on how to set each configuration within your spe
   failure even if it finds a crash in your project, and users will have to
   manually check the logs for detected bugs.
 
-**Note:** Your specific CI system will determine how options are passed to ClusterFuzzLite. Because 
-some CI systems will pass them using environment
-variables, the names of the environment variables can be slightly different than
-names of the corresponding options. In particular, environment variables will be
-all uppercase and use underscores (`_`) instead of hyphens (`-`). For example:
-the environment variable for `fuzz-seconds` is `FUZZ_SECONDS`.
+**Note:** Your specific CI system will determine how options are passed to
+ClusterFuzzLite.
+Because some CI systems will pass them using environment variables, the names of
+the environment variables can be slightly different than names of the
+corresponding options. In particular, environment variables will be all
+uppercase and use underscores (`_`) instead of hyphens (`-`). For example: the
+environment variable for `fuzz-seconds` is `FUZZ_SECONDS`.
 
-At this point you are ready to run ClusterFuzzLite using your specific CI system!
+At this point you are ready to run ClusterFuzzLite using your specific CI
+system!
 Choose the [subguide](#subguides) for your CI system to get started.
 
 ## Supported Continous Integration systems {#subguides}
@@ -167,3 +199,6 @@ Choose the [subguide](#subguides) for your CI system to get started.
 [coverage]: #coverage
 [though this can be changed]: #configuration-options
 [sanitizers]: {{ site.baseurl }}/overview/#sanitizers
+[overview]: {{ site.baseurl }}/assets/overview.png
+[github-actions-crash]: https://storage.googleapis.com/clusterfuzzlite-public/images/github-actions-crash.png
+[github-actions-coverage-report]: https://storage.googleapis.com/clusterfuzzlite-public/images/github-actions-coverage-report.png


### PR DESCRIPTION
1. Viewing PR fuzzing crashes
2. Viewing coverage reports
3. Downloading artifacts/crashes
4. Creating repo secrets

Also fix formatting in running_clusterfuzzlite.md and add some
screenshots there too.
And fix wording regarding only using code coverage (be clear it won't work).