### PR TITLE
Olivekl rework landing page

### DIFF
--- a/docs/build_integration.md
+++ b/docs/build_integration.md
@@ -22,8 +22,7 @@ with our build system, ClusterFuzzLite will be able to use the most recent
 versions of these tools to secure your code.
 
 By the end of the document you will be able to build and run your fuzz targets
-with libFuzzer and a variety of sanitizers. More importantly, your project will
-be ready to be fuzzed by ClusterFuzzLite.
+with libFuzzer and a variety of sanitizers. 
 
 ## Prerequisites
 
@@ -257,8 +256,7 @@ To improve your fuzz target ability to find bugs faster, please read
 
 ## Running ClusterFuzzLite
 
-Once everything is complete, you are ready to set up ClusterFuzzLite to run on
-your CI. Check out the instructions on [Running ClusterFuzzLite] to do this.
+Next: [Step 2: Running ClusterFuzzLite] for directions on setting up ClusterFuzzLite to run on your CI.
 
 [fuzz targets]: https://github.com/google/fuzzing/blob/masteer/docs/glossary.md#fuzz-target
 [libFuzzer targets]: {{ site.baseurl}}/reference/glossary/#fuzz-target

--- a/docs/build_integration.md
+++ b/docs/build_integration.md
@@ -262,4 +262,4 @@ Next: [Step 2: Running ClusterFuzzLite] for directions on setting up ClusterFuzz
 [libFuzzer targets]: {{ site.baseurl}}/reference/glossary/#fuzz-target
 [OSS-Fuzz]: https://github.com/google/oss-fuzz
 [`Dockerfile`]: #dockerfile
-[Running ClusterFuzzLite]: {{ site.baseurl}}/running-clusterfuzzlite/
+[Step 2: Running ClusterFuzzLite]: {{ site.baseurl}}/running-clusterfuzzlite/

--- a/docs/build_integration.md
+++ b/docs/build_integration.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 parent: ClusterFuzzLite
-title: Build Integration
+title: >
+  Step One: Build Integration
 has_children: true
 nav_order: 3
 permalink: /build-integration/

--- a/docs/clusterfuzzlite.md
+++ b/docs/clusterfuzzlite.md
@@ -12,11 +12,6 @@ With just a few lines of code, GitHub users can integrate ClusterFuzzLite into t
 
 ClusterFuzzLite is based on [ClusterFuzz].
 
-## Support
-- C, C++, Java (and other JVM-based languages), Go, Python, Rust, and Swift
-- [GitHub Actions], [Google Cloud Build], and [Prow] (with more CI systems in progress)
-- [Extending support to other CI systems] is easy
-
 ## Features
 
 - Quick code change (pull requests) fuzzing to find bugs before they land  
@@ -27,6 +22,21 @@ ClusterFuzzLite is based on [ClusterFuzz].
 - Coverage reports showing which parts of your code is fuzzed
 - Modular funtionality, so you can decide which features you want to use
 
+## Languages
+- C
+- C++
+- Java (and other JVM-based languages)
+- Go
+- Python
+- Rust
+- Swift
+
+
+## CI Systems
+- [GitHub Actions]
+- [Google Cloud Build]
+- [Prow] (with more CI systems in progress)
+- More CI systems are in development, and [extending support to other CI systems] is easy
 
 ## Library and Sanitizers
 

--- a/docs/clusterfuzzlite.md
+++ b/docs/clusterfuzzlite.md
@@ -41,9 +41,9 @@ ClusterFuzzLite is based on [ClusterFuzz].
 ## Library and Sanitizers
 
 - [libFuzzer] library for coverage-guided testing
-- [AddressSanitizer], for finding memory safety issues
-- [MemorySanitizer], for finding use of uninitialized memory
-- [UndefinedBehaviorSanitizer], for finding undefined behavior (e.g. integer
+- [AddressSanitizer] for finding memory safety issues
+- [MemorySanitizer] for finding use of uninitialized memory
+- [UndefinedBehaviorSanitizer] for finding undefined behavior (e.g. integer
   overflows)
 
 ## Getting Started 

--- a/docs/clusterfuzzlite.md
+++ b/docs/clusterfuzzlite.md
@@ -7,7 +7,7 @@ permalink: /
 ---
 
 # ClusterFuzzLite
-ClusterFuzzLite is a continuous [fuzzing] solution that runs as part of CI/CD workflows to find vulnerabilities faster than ever before. 
+ClusterFuzzLite is a continuous [fuzzing] solution that runs as part of CI workflows to find vulnerabilities faster than ever before. 
 With just a few lines of code, GitHub users can integrate ClusterFuzzLite into their workflow and fuzz pull requests to catch bugs before they are committed, enhancing the overall security of the software supply chain.
 
 ClusterFuzzLite is based on [ClusterFuzz].

--- a/docs/clusterfuzzlite.md
+++ b/docs/clusterfuzzlite.md
@@ -31,7 +31,7 @@ ClusterFuzzLite is based on [ClusterFuzz].
 ## Library and Sanitizers
 
 - [libFuzzer] library for coverage-guided testing
-- [AddressSanitizer], for finding memory safety issues.
+- [AddressSanitizer], for finding memory safety issues
 - [MemorySanitizer], for finding use of uninitialized memory
 - [UndefinedBehaviorSanitizer], for finding undefined behavior (e.g. integer
   overflows)

--- a/docs/clusterfuzzlite.md
+++ b/docs/clusterfuzzlite.md
@@ -7,13 +7,10 @@ permalink: /
 ---
 
 # ClusterFuzzLite
+ClusterFuzzLite is a continuous fuzzing solution that runs as part of CI/CD workflows to find vulnerabilities faster than ever before. 
+With just a few lines of code, GitHub users can integrate ClusterFuzzLite into their workflow and fuzz pull requests to catch bugs before they are committed, enhancing the overall security of the software supply chain.
 
-ClusterFuzzLite makes [fuzzing] part of [Continuous Integration (CI)].
 ClusterFuzzLite is based on [ClusterFuzz].
-
-Fuzzing is a highly effective technique for finding bugs in software.
-ClusterFuzzLite makes your code more secure by fuzzing changes before they even
-enter the codebase.
 
 ## Support
 - C, C++, Java (and other JVM-based languages), Go, Python, Rust, and Swift

--- a/docs/clusterfuzzlite.md
+++ b/docs/clusterfuzzlite.md
@@ -35,7 +35,7 @@ ClusterFuzzLite is based on [ClusterFuzz].
 ## CI Systems
 - [GitHub Actions]
 - [Google Cloud Build]
-- [Prow] (with more CI systems in progress)
+- [Prow] 
 - More CI systems are in development, and [extending support to other CI systems] is easy
 
 ## Library and Sanitizers

--- a/docs/clusterfuzzlite.md
+++ b/docs/clusterfuzzlite.md
@@ -15,36 +15,36 @@ Fuzzing is a highly effective technique for finding bugs in software.
 ClusterFuzzLite makes your code more secure by fuzzing changes before they even
 enter the codebase.
 
-ClusterFuzzLite supports [GitHub Actions], [Google Cloud Build], and [Prow], so
-getting the benefits of continuous fuzzing is simple if you can use these CI
-systems.
-Suppport for more CI systems is in-progress and [extending support to other CI
+## Support
+- C, C++, Java (and other JVM-based languages), Go, Python, Rust, and Swift
+- [GitHub Actions], [Google Cloud Build], and [Prow] (with more CI systems in progress)
+- Suppport for more CI systems is in-progress and [extending support to other CI
 systems] is easy.
-ClusterFuzzLite supports programming languages and runtimes beyond C and C++,
-including Java (and other JVM-based languages), Go, Python, Rust, and Swift.
 
-ClusterFuzzLite offers many useful features, including:
+## Features
+
 - Quickly fuzzing code changes (pull requests) before they land and allowing
-   you to download the crashing testcases.
+   you to download the crashing testcases
 - Continuous longer running fuzzing (batch fuzzing) that asynchronously find
    deeper bugs missed during code change fuzzing and build a minimal corpus for
-   use in code change fuzzing.
-- Coverage reports, so users can see which parts of their code is fuzzed.
+   use in code change fuzzing
+- Coverage reports, so users can see which parts of their code is fuzzed
+- Modular funtionality, so you can decide which features you want to use
 
-ClusterFuzzLite is modular, so you can decide which features you want to use.
 
-ClusterFuzzLite uses [libFuzzer] and important sanitizers for finding bugs in
-C/C++ code:
+## Library and Sanitizers
+
+- [libFuzzer] library for coverage-guided testing
 - [AddressSanitizer], for finding memory safety issues.
 - [MemorySanitizer], for finding use of uninitialized memory.
 - [UndefinedBehaviorSanitizer], for finding undefined behavior (e.g. integer
   overflows).
 
+## Getting Started 
+
 If you're new to using libFuzzer and sanitizers, start with the [Overview] for an explanation of terms and the fuzzing process. 
 
-If you're already familiar with using libFuzzer and sanitizers, you're ready to begin fuzzing with ClusterFuzzLite. Using ClusterFuzzLite is simple and requires two major steps:
-1. [Writing fuzzers and integrating with ClusterFuzzLite's build system]
-1. [Configuring ClusterFuzzLite to run in your CI]
+If you're already familiar with using libFuzzer and sanitizers, start with [Step 1: Build Integration].
 
 [Continuous Integration (CI)]: https://en.wikipedia.org/wiki/Continuous_integration
 [fuzzing]: https://en.wikipedia.org/wiki/Fuzzing
@@ -57,7 +57,7 @@ If you're already familiar with using libFuzzer and sanitizers, you're ready to 
 [libFuzzer]: https://llvm.org/docs/LibFuzzer.html
 [AddressSanitizer]: https://clang.llvm.org/docs/AddressSanitizer.html
 [UndefinedBehaviorSanitizer]: https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html
-[Writing fuzzers and integrating with ClusterFuzzLite's build system]: {{ site.baseurl }}/build-integration/
+[Step 1: Build Integration]: {{ site.baseurl }}/build-integration/
 [Running ClusterFuzzLite]: {{ site.baseurl }}/running-clusterfuzzlite/
 [Configuring ClusterFuzzLite to run in your CI]: {{ site.baseurl }}/running-clusterfuzzlite/
 [MemorySanitizer]: https://clang.llvm.org/docs/MemorySanitizer.html

--- a/docs/clusterfuzzlite.md
+++ b/docs/clusterfuzzlite.md
@@ -15,7 +15,7 @@ ClusterFuzzLite is based on [ClusterFuzz].
 ## Support
 - C, C++, Java (and other JVM-based languages), Go, Python, Rust, and Swift
 - [GitHub Actions], [Google Cloud Build], and [Prow] (with more CI systems in progress)
-- [Extending support to other CI systems] is easy.
+- [Extending support to other CI systems] is easy
 
 ## Features
 
@@ -32,9 +32,9 @@ ClusterFuzzLite is based on [ClusterFuzz].
 
 - [libFuzzer] library for coverage-guided testing
 - [AddressSanitizer], for finding memory safety issues.
-- [MemorySanitizer], for finding use of uninitialized memory.
+- [MemorySanitizer], for finding use of uninitialized memory
 - [UndefinedBehaviorSanitizer], for finding undefined behavior (e.g. integer
-  overflows).
+  overflows)
 
 ## Getting Started 
 

--- a/docs/clusterfuzzlite.md
+++ b/docs/clusterfuzzlite.md
@@ -7,7 +7,7 @@ permalink: /
 ---
 
 # ClusterFuzzLite
-ClusterFuzzLite is a continuous fuzzing solution that runs as part of CI/CD workflows to find vulnerabilities faster than ever before. 
+ClusterFuzzLite is a continuous [fuzzing] solution that runs as part of CI/CD workflows to find vulnerabilities faster than ever before. 
 With just a few lines of code, GitHub users can integrate ClusterFuzzLite into their workflow and fuzz pull requests to catch bugs before they are committed, enhancing the overall security of the software supply chain.
 
 ClusterFuzzLite is based on [ClusterFuzz].
@@ -53,7 +53,7 @@ If you're new to using libFuzzer and sanitizers, start with the [Overview] for a
 If you're already familiar with using libFuzzer and sanitizers, start with [Step 1: Build Integration].
 
 [Continuous Integration (CI)]: https://en.wikipedia.org/wiki/Continuous_integration
-[fuzzing]: https://en.wikipedia.org/wiki/Fuzzing
+[fuzzing]: {{ site.baseurl }}/overview.md#fuzzing
 [ClusterFuzz]: https://google.github.io/clusterfuzz/
 [GitHub Actions]: {{ site.baseurl }}/running-clusterfuzzlite/github-actions/
 [Prow]: {{ site.baseurl }}/running-clusterfuzzlite/prow/

--- a/docs/clusterfuzzlite.md
+++ b/docs/clusterfuzzlite.md
@@ -19,12 +19,12 @@ ClusterFuzzLite is based on [ClusterFuzz].
 
 ## Features
 
-- Quickly fuzzing code changes (pull requests) before they land and allowing
-   you to download the crashing testcases
-- Continuous longer running fuzzing (batch fuzzing) that asynchronously find
+- Quick code change (pull requests) fuzzing to find bugs before they land  
+- Downloads of crashing testcases
+- Continuous longer running fuzzing (batch fuzzing) to asynchronously find
    deeper bugs missed during code change fuzzing and build a minimal corpus for
    use in code change fuzzing
-- Coverage reports, so users can see which parts of their code is fuzzed
+- Coverage reports showing which parts of your code is fuzzed
 - Modular funtionality, so you can decide which features you want to use
 
 

--- a/docs/clusterfuzzlite.md
+++ b/docs/clusterfuzzlite.md
@@ -15,8 +15,7 @@ ClusterFuzzLite is based on [ClusterFuzz].
 ## Support
 - C, C++, Java (and other JVM-based languages), Go, Python, Rust, and Swift
 - [GitHub Actions], [Google Cloud Build], and [Prow] (with more CI systems in progress)
-- Suppport for more CI systems is in-progress and [extending support to other CI
-systems] is easy.
+- [Extending support to other CI systems] is easy.
 
 ## Features
 

--- a/docs/clusterfuzzlite.md
+++ b/docs/clusterfuzzlite.md
@@ -8,7 +8,7 @@ permalink: /
 
 # ClusterFuzzLite
 ClusterFuzzLite is a continuous [fuzzing] solution that runs as part of CI workflows to find vulnerabilities faster than ever before. 
-With just a few lines of code, GitHub users can integrate ClusterFuzzLite into their workflow and fuzz pull requests to catch bugs before they are committed, enhancing the overall security of the software supply chain.
+With just a few lines of code, GitHub users can integrate ClusterFuzzLite into their workflow and fuzz pull requests to catch bugs before they are committed.
 
 ClusterFuzzLite is based on [ClusterFuzz].
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -16,7 +16,7 @@ to begin writing fuzzers and integrating with ClusterFuzzLite's build system.
 
 ### Fuzzing
 
-[Fuzzing] is a technique were randomized inputs are automatically created and
+[Fuzzing] is a technique where randomized inputs are automatically created and
 fed as input to a (target) program in order to find bugs in that program.
 The program that creates the inputs is called a fuzzer.
 Fuzzing is highly effective at finding bugs missed by manually written tests,

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -77,8 +77,7 @@ The ClusterFuzzLite codebase uses shorter names for the sanitizers. When
 referring to a sanitizer as an input to ClusterFuzzLite, ASan is
 `address`, UBSan is `ubsan` and MSan is `memory`.
 
-With that, you have enough background to build fuzzers for ClusterFuzzLite. Continue on 
-to [Build Integration] for directions on integrating your project with ClusterFuzzLite's build system. 
+Next: [Step 1: Build Integration] for directions on integrating your project with ClusterFuzzLite's build system. 
 
 [Fuzzing]: https://en.wikipedia.org/wiki/Fuzzing
 [LibFuzzer]: https://llvm.org/docs/LibFuzzer.html
@@ -86,4 +85,4 @@ to [Build Integration] for directions on integrating your project with ClusterFu
 [AddressSanitizer (ASan)]: https://clang.llvm.org/docs/AddressSanitizer.html
 [UndefinedBehaviorSanitizer (UBSan)]: https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html
 [MemorySanitizer (MSan)]: https://clang.llvm.org/docs/MemorySanitizer.html
-[Build Integration]: {{ site.baseurl }}/build-integration/
+[Step 1: Build Integration]: {{ site.baseurl }}/build-integration/

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -11,7 +11,7 @@ permalink: /overview/
 ## Introducing fuzzing with libFuzzer and Sanitizers.
 
 This section provides an overview of the fuzzing process and defines common terms. 
-If you are already familiar with libFuzzer and Sanitizers, feel free to skip to [Build Integration] 
+If you are already familiar with libFuzzer and Sanitizers, feel free to skip to [Step 1: Build Integration] 
 to begin writing fuzzers and integrating with ClusterFuzzLite's build system.
 
 ### Fuzzing

--- a/docs/running_clusterfuzzlite.md
+++ b/docs/running_clusterfuzzlite.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 parent: ClusterFuzzLite
-title: Running ClusterFuzzLite
+title: > 
+   Step 2: Running ClusterFuzzLite
 has_children: true
 nav_order: 4
 permalink: /running-clusterfuzzlite/

--- a/docs/running_clusterfuzzlite.md
+++ b/docs/running_clusterfuzzlite.md
@@ -31,7 +31,7 @@ that are agnostic to which CI system you are using.
 After reading this page, see the [subguides] for instructions specific to your
 particular CI system (e.g. [GitHub Actions] or [Google Cloud Build]).
 
-## ClusterFuzzLite modes
+## ClusterFuzzLite Modes
 
 ClusterFuzzLite offers two primary modes of fuzzing: [code change fuzzing] and
 [batch fuzzing].
@@ -179,7 +179,7 @@ At this point you are ready to run ClusterFuzzLite using your specific CI
 system!
 Choose the [subguide](#subguides) for your CI system to get started.
 
-## Supported Continous Integration systems {#subguides}
+## Supported Continous Integration Systems {#subguides}
 
 - [GitHub Actions]
 - [Google Cloud Build]

--- a/docs/running_clusterfuzzlite.md
+++ b/docs/running_clusterfuzzlite.md
@@ -14,13 +14,12 @@ permalink: /running-clusterfuzzlite/
 {:toc}
 ---
 
-## Overview
-![overview]
-
 Before running ClusterFuzzLite, you must integrate your project with
 ClusterFuzzLite's build system to build your project's fuzzers.
-See [Integrating with ClusterFuzzLite's build system] if you haven't already
-taken this step.
+See [Step 1: Build Integration] if you haven't already taken this step.
+
+## Overview
+![overview]
 
 Once your project's fuzzers can be built and run by the OSS-Fuzz/ClusterFuzzLite
 helper script, it is ready to be fuzzed by ClusterFuzzLite.
@@ -188,7 +187,7 @@ Choose the [subguide](#subguides) for your CI system to get started.
 
 [subguides]: #subguides
 [Google Cloud Build]: {{ site.baseurl }}/google-cloud-build/
-[integrating with ClusterFuzzLite's build system]: {{ site.baseurl }}/build-integration/
+[Step 1: Build Integration]: {{ site.baseurl }}/build-integration/
 [Batch Fuzzing]: #batch-fuzzing-batch
 [Code Coverage report generation]: #code-coverage-report-generation-coverage
 [this explanation]: {{ site.baseurl }}/build-integration/#language


### PR DESCRIPTION
Simply landing page: cut prose and replace with bulleted lists, rework opening project description 

Add "Step 1" and "Step 2" to navigation heading titles (Step 1: Build Integration; Step 2: Running ClusterFuzzLite)
Clarify transitions between pages (i.e., "Next: Step 1, Build Integration for directions on...)
