### PR TITLE
docs: cancel "PR" and "Build" jobs and pass GITHUB_TOKEN when fuzzers are built

### DIFF
--- a/docs/running-clusterfuzzlite/github_actions.md
+++ b/docs/running-clusterfuzzlite/github_actions.md
@@ -72,6 +72,7 @@ jobs:
       id: build
       uses: google/clusterfuzzlite/actions/build_fuzzers@v1
       with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         sanitizer: ${{ matrix.sanitizer }}
         # Optional but recommended: used to only run fuzzers that are affected
         # by the PR.

--- a/docs/running-clusterfuzzlite/github_actions.md
+++ b/docs/running-clusterfuzzlite/github_actions.md
@@ -56,6 +56,9 @@ permissions: read-all
 jobs:
   PR:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.sanitizer }}-${{ github.ref }}
+      cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:
@@ -206,6 +209,9 @@ permissions: read-all
 jobs:
   Build:
    runs-on: ubuntu-latest
+   concurrency:
+     group: ${{ github.workflow }}-${{ matrix.sanitizer }}-${{ github.ref }}
+     cancel-in-progress: true
    strategy:
      fail-fast: false
      matrix:


### PR DESCRIPTION
[v1]
docs: cancel "PR" and "Build" jobs on every push

This should help to save some time and storage when PRs/codebases
are updated

[v2]
docs: pass GITHUB_TOKEN to PR jobs when fuzzers are built as well

The "build fuzzers" step needs the token to download coverage data.
Without it it fails with
```
root - INFO - Removing unaffected fuzz targets.
root - INFO - Diffing against master.
root - INFO - Files changed in PR: ['.clusterfuzzlite/bpf-object-fuzzer.c']
root - ERROR - Request to https://api.github.com/repos/evverx/libbpf/actions/artifacts?per_page=100&page=1 failed. Code: 401. Response: {'message': 'Bad credentials', 'documentation_url': 'https://docs.github.com/rest'}
root - ERROR - Could not get coverage: Github API request failed..
root - ERROR - Could not find latest coverage report.
```

Technically it's not necessary to pass it when coverage reports aren't
generated but since this particular workflow runs on PRs the token is
mostly read-only so it should be safe to always pass it around.

Closes google#78