### PR TITLE
Switch to the latest images

### DIFF
--- a/actions/build_fuzzers/action.yml
+++ b/actions/build_fuzzers/action.yml
@@ -53,7 +53,7 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: 'docker://gcr.io/oss-fuzz-base/clusterfuzzlite-build-fuzzers:v1'
+  image: 'docker://gcr.io/oss-fuzz-base/clusterfuzzlite-build-fuzzers:latest'
   env:
     ALLOWED_BROKEN_TARGETS_PERCENTAGE: ${{ inputs.allowed-broken-targets-percentage}}
     BAD_BUILD_CHECK: ${{ inputs.bad-build-check }}

--- a/actions/run_fuzzers/action.yml
+++ b/actions/run_fuzzers/action.yml
@@ -58,7 +58,7 @@ inputs:
     default: False
 runs:
   using: 'docker'
-  image: 'docker://gcr.io/oss-fuzz-base/clusterfuzzlite-run-fuzzers:v1'
+  image: 'docker://gcr.io/oss-fuzz-base/clusterfuzzlite-run-fuzzers:latest'
   env:
     FUZZ_SECONDS: ${{ inputs.fuzz-seconds }}
     MODE: ${{ inputs.mode }}


### PR DESCRIPTION
CFLite can't be pinned properly so to unpin it it should be
possible to always use the latest images.

This reverts https://github.com/google/clusterfuzzlite/pull/2

Closes https://github.com/google/clusterfuzzlite/issues/95