### PR TITLE
add language:c++ to github actions examples

### DIFF
--- a/docs/running-clusterfuzzlite/github_actions.md
+++ b/docs/running-clusterfuzzlite/github_actions.md
@@ -72,6 +72,7 @@ jobs:
       id: build
       uses: google/clusterfuzzlite/actions/build_fuzzers@v1
       with:
+        language: c++
         github-token: ${{ secrets.GITHUB_TOKEN }}
         sanitizer: ${{ matrix.sanitizer }}
         # Optional but recommended: used to only run fuzzers that are affected
@@ -143,6 +144,7 @@ jobs:
       id: build
       uses: google/clusterfuzzlite/actions/build_fuzzers@v1
       with:
+        language: c++
         sanitizer: ${{ matrix.sanitizer }}
     - name: Run Fuzzers (${{ matrix.sanitizer }})
       id: run
@@ -226,8 +228,9 @@ jobs:
      id: build
      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
      with:
-       sanitizer: ${{ matrix.sanitizer }}
-       upload-build: true
+        language: c++
+        sanitizer: ${{ matrix.sanitizer }}
+        upload-build: true
 ```
 {% endraw %}
 
@@ -255,6 +258,8 @@ jobs:
     - name: Build Fuzzers
       id: build
       uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        language: c++
     - name: Run Fuzzers
       id: run
       uses: google/clusterfuzzlite/actions/run_fuzzers@v1
@@ -290,6 +295,7 @@ jobs:
       id: build
       uses: google/clusterfuzzlite/actions/build_fuzzers@v1
       with:
+        language: c++
         sanitizer: coverage
     - name: Run Fuzzers
       id: run


### PR DESCRIPTION
While setting up a JVM fuzzing demo with Github Actions, I ran into the [build_fuzzers step not working](https://github.com/jtpereyda/clusterfuzzlite-demo/pull/4) unless I specify `language: jvm` -- they seem to build fine but get tripped up on checking the build. I didn't find the language argument until I checked https://github.com/google/clusterfuzzlite/blob/main/actions/build_fuzzers/action.yml.

I saw that https://google.github.io/clusterfuzzlite/running-clusterfuzzlite/google-cloud-build/ and https://google.github.io/clusterfuzzlite/running-clusterfuzzlite/gitlab/ both mention how to specify the language. So `github_actions.md` seems like the right place. I figure one easy way is to just throw `language: c++` in the examples, and people will probably think to change it.

As an aside: It would be nifty for `project.yaml`'s `language` to be a default for any build integrations.