### PR TITLE
Removed Demo gif from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ ClusterFuzzLite is based on [ClusterFuzz](https://google.github.io/clusterfuzz/)
 - Coverage reports showing which parts of your code are fuzzed
 - Modular functionality, so you can decide which features you want to use
 
-![demo](https://storage.googleapis.com/clusterfuzzlite-public/images/demo.gif)
-
 ## Supported Languages
 - C
 - C++


### PR DESCRIPTION
Discussed with @olivekl. The demo gif is not adding value. It is too fast, the type is too small, etc. I am willing to work with folks to add screenshots and text to the README if the team would like to provide users with a taste of what the project is like. 